### PR TITLE
Add UITabBarController.configureViewControllers

### DIFF
--- a/Perform.xcodeproj/project.pbxproj
+++ b/Perform.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		4AC9E4E31D74C9620064B4E7 /* UIStoryboardSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9E4E21D74C9620064B4E7 /* UIStoryboardSegue.swift */; };
 		4AEFD48A1D760122004E7F66 /* UITabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD4891D760122004E7F66 /* UITabBarController.swift */; };
 		4AEFD48C1D7601A4004E7F66 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD48B1D7601A4004E7F66 /* UIViewController.swift */; };
+		4AEFD4901D76089F004E7F66 /* SequenceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD48F1D76089F004E7F66 /* SequenceType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +100,7 @@
 		4AC9E4E21D74C9620064B4E7 /* UIStoryboardSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardSegue.swift; sourceTree = "<group>"; };
 		4AEFD4891D760122004E7F66 /* UITabBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITabBarController.swift; sourceTree = "<group>"; };
 		4AEFD48B1D7601A4004E7F66 /* UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
+		4AEFD48F1D76089F004E7F66 /* SequenceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SequenceType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -196,6 +198,7 @@
 				4AA18A4C1D75D738005386FF /* CollectionType.swift */,
 				4A9593C91D74940600EE27AA /* Perform.swift */,
 				4AC9E4D51D74BBD70064B4E7 /* Segue.swift */,
+				4AEFD48F1D76089F004E7F66 /* SequenceType.swift */,
 				4AC9E4E21D74C9620064B4E7 /* UIStoryboardSegue.swift */,
 				4AEFD4891D760122004E7F66 /* UITabBarController.swift */,
 				4AEFD48B1D7601A4004E7F66 /* UIViewController.swift */,
@@ -366,6 +369,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4AEFD4901D76089F004E7F66 /* SequenceType.swift in Sources */,
 				4AA18A4F1D75D75D005386FF /* Aspects.swift in Sources */,
 				4AEFD48A1D760122004E7F66 /* UITabBarController.swift in Sources */,
 				4AC9E4E31D74C9620064B4E7 /* UIStoryboardSegue.swift in Sources */,

--- a/Perform.xcodeproj/project.pbxproj
+++ b/Perform.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		4AC9E4D61D74BBD70064B4E7 /* Segue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9E4D51D74BBD70064B4E7 /* Segue.swift */; };
 		4AC9E4E11D74C2C40064B4E7 /* ViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9E4DF1D74C2390064B4E7 /* ViewControllers.swift */; };
 		4AC9E4E31D74C9620064B4E7 /* UIStoryboardSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9E4E21D74C9620064B4E7 /* UIStoryboardSegue.swift */; };
+		4AEFD48A1D760122004E7F66 /* UITabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD4891D760122004E7F66 /* UITabBarController.swift */; };
+		4AEFD48C1D7601A4004E7F66 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFD48B1D7601A4004E7F66 /* UIViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +97,8 @@
 		4AC9E4D51D74BBD70064B4E7 /* Segue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Segue.swift; sourceTree = "<group>"; };
 		4AC9E4DF1D74C2390064B4E7 /* ViewControllers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllers.swift; sourceTree = "<group>"; };
 		4AC9E4E21D74C9620064B4E7 /* UIStoryboardSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardSegue.swift; sourceTree = "<group>"; };
+		4AEFD4891D760122004E7F66 /* UITabBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITabBarController.swift; sourceTree = "<group>"; };
+		4AEFD48B1D7601A4004E7F66 /* UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -193,6 +197,8 @@
 				4A9593C91D74940600EE27AA /* Perform.swift */,
 				4AC9E4D51D74BBD70064B4E7 /* Segue.swift */,
 				4AC9E4E21D74C9620064B4E7 /* UIStoryboardSegue.swift */,
+				4AEFD4891D760122004E7F66 /* UITabBarController.swift */,
+				4AEFD48B1D7601A4004E7F66 /* UIViewController.swift */,
 				4A9593C51D7493EC00EE27AA /* Info.plist */,
 			);
 			path = Perform;
@@ -361,9 +367,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				4AA18A4F1D75D75D005386FF /* Aspects.swift in Sources */,
+				4AEFD48A1D760122004E7F66 /* UITabBarController.swift in Sources */,
 				4AC9E4E31D74C9620064B4E7 /* UIStoryboardSegue.swift in Sources */,
 				4AA18A4D1D75D738005386FF /* CollectionType.swift in Sources */,
 				4A95940A1D74B16D00EE27AA /* Perform.swift in Sources */,
+				4AEFD48C1D7601A4004E7F66 /* UIViewController.swift in Sources */,
 				4AC9E4D61D74BBD70064B4E7 /* Segue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Perform/SequenceType.swift
+++ b/Sources/Perform/SequenceType.swift
@@ -1,0 +1,11 @@
+extension SequenceType {
+  func first<Result>(isMatch: (Generator.Element) -> Result?) -> Result? {
+    for element in self {
+      if let result = isMatch(element) {
+        return result
+      }
+    }
+
+    return nil
+  }
+}

--- a/Sources/Perform/UIStoryboardSegue.swift
+++ b/Sources/Perform/UIStoryboardSegue.swift
@@ -3,16 +3,6 @@ import UIKit
 extension UIStoryboardSegue {
   @nonobjc
   public final func destinationViewController<Destination: UIViewController>(ofType type: Destination.Type) -> Destination? {
-    var queue: [UIViewController] = [destinationViewController]
-
-    while let viewController = queue.popLast() {
-      queue.insertContentsOf(viewController.childViewControllers, at: 0)
-
-      if let destination = viewController as? Destination {
-        return destination
-      }
-    }
-
-    return nil
+    return destinationViewController.hierarchy.first { $0 as? Destination }
   }
 }

--- a/Sources/Perform/UIStoryboardSegue.swift
+++ b/Sources/Perform/UIStoryboardSegue.swift
@@ -3,6 +3,6 @@ import UIKit
 extension UIStoryboardSegue {
   @nonobjc
   public final func destinationViewController<Destination: UIViewController>(ofType type: Destination.Type) -> Destination? {
-    return destinationViewController.hierarchy.first { $0 as? Destination }
+    return destinationViewController.childViewController(ofType: type)
   }
 }

--- a/Sources/Perform/UITabBarController.swift
+++ b/Sources/Perform/UITabBarController.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+extension UITabBarController {
+  public func configureTabs(@noescape configure: (UIViewController) -> Void) {
+    let hierarchy = (viewControllers ?? []).lazy.flatMap { $0.hierarchy }
+    hierarchy.forEach(configure)
+  }
+}

--- a/Sources/Perform/UITabBarController.swift
+++ b/Sources/Perform/UITabBarController.swift
@@ -1,6 +1,28 @@
 import UIKit
 
 extension UITabBarController {
+  /// For each view controller in `viewControllers`, iterate over its view
+  /// controller hierarchy, passing each view controller to `configure`.
+  ///
+  /// **Example**
+  ///
+  ///     class AppController: UITabBarController {
+  ///       let taskList = TaskList.shared
+  ///
+  ///       override func viewDidLoad() {
+  ///         super.viewDidLoad()
+  ///
+  ///         configureViewControllers { viewController in
+  ///           if let tasks = viewController as? TasksViewController {
+  ///             tasks.taskList = taskList
+  ///           }
+  ///         }
+  ///       }
+  ///     }
+  ///
+  /// - parameter configure:
+  ///     A function that will be invoked once with each view controller
+  ///     in each tab's view controller hierarchy.
   public func configureViewControllers(@noescape configure: (UIViewController) -> Void) {
     let hierarchy = (viewControllers ?? []).lazy.flatMap { $0.hierarchy }
     hierarchy.forEach(configure)

--- a/Sources/Perform/UITabBarController.swift
+++ b/Sources/Perform/UITabBarController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 extension UITabBarController {
-  public func configureTabs(@noescape configure: (UIViewController) -> Void) {
+  public func configureViewControllers(@noescape configure: (UIViewController) -> Void) {
     let hierarchy = (viewControllers ?? []).lazy.flatMap { $0.hierarchy }
     hierarchy.forEach(configure)
   }

--- a/Sources/Perform/UIViewController.swift
+++ b/Sources/Perform/UIViewController.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+extension UIViewController {
+  var hierarchy: AnySequence<UIViewController> {
+    return AnySequence { () -> AnyGenerator<UIViewController> in
+      var queue = [self]
+
+      return AnyGenerator {
+        if let next = queue.popLast() {
+          queue.insertContentsOf(next.childViewControllers, at: 0)
+          return next
+        } else {
+          return nil
+        }
+      }
+    }
+  }
+}

--- a/Sources/Perform/UIViewController.swift
+++ b/Sources/Perform/UIViewController.swift
@@ -1,6 +1,10 @@
 import UIKit
 
 extension UIViewController {
+  public func childViewController<Child: UIViewController>(ofType type: Child.Type) -> Child? {
+    return hierarchy.first { $0 as? Child }
+  }
+
   var hierarchy: AnySequence<UIViewController> {
     return AnySequence { () -> AnyGenerator<UIViewController> in
       var queue = [self]

--- a/Sources/Perform/UIViewController.swift
+++ b/Sources/Perform/UIViewController.swift
@@ -1,6 +1,14 @@
 import UIKit
 
 extension UIViewController {
+  /// Perform a breadth-first search of the receiver's view controller hierarchy,
+  /// returning the first view controller matching the given `type`, or nil.
+  ///
+  /// - parameter type:
+  ///     The type of the view controller to search for.
+  ///
+  /// - returns:
+  ///     The first view controller matching the given `type`, or nil.
   public func childViewController<Child: UIViewController>(ofType type: Child.Type) -> Child? {
     return hierarchy.first { $0 as? Child }
   }

--- a/Tests/Harness/Base.lproj/Main.storyboard
+++ b/Tests/Harness/Base.lproj/Main.storyboard
@@ -74,6 +74,62 @@
             </objects>
             <point key="canvasLocation" x="916" y="110"/>
         </scene>
+        <!--Profile-->
+        <scene sceneID="8hS-Od-JCZ">
+            <objects>
+                <viewController id="8Xc-O0-Oka" customClass="Profile" customModule="PerformHarness" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="pGK-SH-ZjP"/>
+                        <viewControllerLayoutGuide type="bottom" id="p11-1c-kec"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="3i1-Zx-IHR">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Profile" id="Z0a-yC-eNT"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="C7k-Zh-jJJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="974" y="1647"/>
+        </scene>
+        <!--Feed-->
+        <scene sceneID="9kt-OZ-oWO">
+            <objects>
+                <viewController id="IE1-mc-wV3" customClass="Feed" customModule="PerformHarness" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="mIa-P5-VNh"/>
+                        <viewControllerLayoutGuide type="bottom" id="TTV-Ya-d1c"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="ESb-Kc-6Qx">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Feed" id="Htr-kq-02q"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qAe-9R-lUW" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="974" y="992"/>
+        </scene>
+        <!--Tab Bar Controller-->
+        <scene sceneID="5cN-Wg-QbL">
+            <objects>
+                <tabBarController storyboardIdentifier="Tabs" id="XVG-FP-JwE" sceneMemberID="viewController">
+                    <tabBar key="tabBar" contentMode="scaleToFill" id="OGP-m2-hGn">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="49"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    </tabBar>
+                    <connections>
+                        <segue destination="IE1-mc-wV3" kind="relationship" relationship="viewControllers" id="hvS-65-Xd0"/>
+                        <segue destination="8Xc-O0-Oka" kind="relationship" relationship="viewControllers" id="6aV-Lr-o11"/>
+                    </connections>
+                </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="UY2-zR-skX" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="20" y="1318"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="3qI-wk-cbL">
             <objects>

--- a/Tests/Harness/ViewControllers.swift
+++ b/Tests/Harness/ViewControllers.swift
@@ -6,3 +6,9 @@ final class Detail: UIViewController {
 
 final class Form: UITableViewController {
 }
+
+final class Feed: UITableViewController {
+}
+
+final class Profile: UITableViewController {
+}

--- a/Tests/PerformTests/PerformSpec.swift
+++ b/Tests/PerformTests/PerformSpec.swift
@@ -12,13 +12,18 @@ extension Segue {
 
 final class PerformSpec: QuickSpec {
   override func spec() {
+    let storyboard = UIStoryboard(name: "Main", bundle: nil)
+
     describe("perform") {
       var root: UIViewController?
 
       beforeEach {
-        let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let nav = storyboard.instantiateInitialViewController() as? UINavigationController
         root = nav?.topViewController
+      }
+
+      afterEach {
+        root = nil
       }
 
       it("passes the destination view controller to the completion block") {
@@ -49,6 +54,37 @@ final class PerformSpec: QuickSpec {
         }
 
         expect(form).to(beAKindOf(Form.self))
+      }
+    }
+
+    describe("configureTabs") {
+      var controller: UITabBarController?
+
+      beforeEach {
+        controller = storyboard.instantiateViewControllerWithIdentifier("Tabs") as? UITabBarController
+      }
+
+      afterEach {
+        controller = nil
+      }
+
+      it("configures each tab in turn") {
+        var configured: [String] = []
+
+        controller?.configureTabs { child in
+          switch child {
+          case is Feed:
+            configured.append("Feed")
+
+          case is Profile:
+            configured.append("Profile")
+
+          default:
+            break
+          }
+        }
+
+        expect(configured).to(equal(["Feed", "Profile"]))
       }
     }
   }

--- a/Tests/PerformTests/PerformSpec.swift
+++ b/Tests/PerformTests/PerformSpec.swift
@@ -57,7 +57,7 @@ final class PerformSpec: QuickSpec {
       }
     }
 
-    describe("configureTabs") {
+    describe("configureViewControllers") {
       var controller: UITabBarController?
 
       beforeEach {
@@ -71,8 +71,8 @@ final class PerformSpec: QuickSpec {
       it("configures each tab in turn") {
         var configured: [String] = []
 
-        controller?.configureTabs { child in
-          switch child {
+        controller?.configureViewControllers { viewController in
+          switch viewController {
           case is Feed:
             configured.append("Feed")
 


### PR DESCRIPTION
Fixes #6.

Simplifies passing dependencies to tabs within a tab bar controller by searching within each tab's view controller hierarchy for a matching view controller to configure.
