### PR TITLE
Don't use private API in Release builds

### DIFF
--- a/Sources/Perform/Perform.swift
+++ b/Sources/Perform/Perform.swift
@@ -38,9 +38,13 @@ extension UIViewController {
   public func perform<Destination: UIViewController>(segue: Segue<Destination>, prepare: (Destination) -> Void = { _ in }) {
     performSegue(withIdentifier: segue.identifier) { segue, _ in
       guard let destination = segue.destinationViewController(ofType: Destination.self) else {
-        let printHierarchy = "_printHierarchy"
-        let hierarchy = segue.destinationViewController.performSelector(Selector(printHierarchy)).takeUnretainedValue()
-        fatalError("expected destination view controller hierarchy to include \(Destination.self), got:\n\(hierarchy)")
+        #if DEBUG
+          let printHierarchy = "_printHierarchy"
+          let hierarchy = segue.destinationViewController.performSelector(Selector(printHierarchy)).takeUnretainedValue()
+          fatalError("expected destination view controller hierarchy to include \(Destination.self), got:\n\(hierarchy)")
+        #else
+          fatalError("expected destination view controller hierarchy to include \(Destination.self)")
+        #endif
       }
       prepare(destination)
     }

--- a/Sources/Perform/Perform.swift
+++ b/Sources/Perform/Perform.swift
@@ -36,14 +36,14 @@ extension UIViewController {
   ///     and crash. This usually means that the view controller hasn't
   ///     been configured with the correct type in the storyboard.
   public func perform<Destination: UIViewController>(segue: Segue<Destination>, prepare: (Destination) -> Void = { _ in }) {
-    performSegue(withIdentifier: segue.identifier) { segue, _ in
+    performSegue(withIdentifier: segue.identifier) { [segueDescription = { String(reflecting: segue) }] segue, _ in
       guard let destination = segue.destinationViewController(ofType: Destination.self) else {
         #if DEBUG
           let printHierarchy = "_printHierarchy"
           let hierarchy = segue.destinationViewController.performSelector(Selector(printHierarchy)).takeUnretainedValue()
-          fatalError("expected destination view controller hierarchy to include \(Destination.self), got:\n\(hierarchy)")
+          fatalError("\(segueDescription()): expected destination view controller hierarchy to include \(Destination.self), got:\n\(hierarchy)")
         #else
-          fatalError("expected destination view controller hierarchy to include \(Destination.self)")
+          fatalError("\(segueDescription()): expected destination view controller hierarchy to include \(Destination.self)")
         #endif
       }
       prepare(destination)


### PR DESCRIPTION
The use of `_printHierarchy` is purely for debugging purposes, and should be excluded from release builds where it could cause app rejections.

Unfortunately this means that anyone using prebuilt Carthage binaries probably will never see the debug version of the message.
